### PR TITLE
hotfix: require msgpack >= 1.0.0

### DIFF
--- a/microscope/microscope.py
+++ b/microscope/microscope.py
@@ -20,7 +20,7 @@ class Comm:
 
     def get_config(self):
         self.ser.write(Comm.magic + b"\x00")
-        return next(msgpack.Unpacker(self.ser, read_size=1, encoding="utf-8"))
+        return next(msgpack.Unpacker(self.ser, read_size=1))
 
     def select(self, insert):
         self.ser.write(Comm.magic + b"\x01" + struct.pack("B", insert))

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "Programming Language :: Python",
     ],
     packages=find_packages(),
-    install_requires=["migen", "pyserial", "msgpack", "prettytable"],
+    install_requires=["migen", "pyserial", "msgpack>=1.0.0", "prettytable"],
     include_package_data=True,
     entry_points={
         "console_scripts": ["microscope = microscope.microscope:main"],


### PR DESCRIPTION
Closing #4.

## Explanation

`msgpack` has been bumped to 1.0.0 in [nixpkgs 20.09](https://github.com/NixOS/nixpkgs/blob/cd63096d6d887d689543a0b97743d28995bc9bc3/pkgs/development/python-modules/msgpack/default.nix#L9). Nix development environments that use `microscope` (e.g. ARTIQ's nix-shell)  requires the latest `msgpack` API to work.